### PR TITLE
Added 'auto = format' URL Parameter To Image

### DIFF
--- a/src/lib/SanityImage.svelte
+++ b/src/lib/SanityImage.svelte
@@ -31,7 +31,7 @@
 {#if browser && image}
   <img
     loading="lazy"
-    src={urlFor(image).width(maxWidth).fit('fillmax')}
+    src={urlFor(image).width(maxWidth).fit('fillmax').auto('format')}
     alt={alt || image.alt || ''}
     class:loaded
     bind:this={imageRef}


### PR DESCRIPTION
Set auto=format to automatically return an image in webp formatting if the browser supports it. This fulfills the '
Serve images in next-gen formats'  lighthouse requirement and improves lighthouse performance scores.